### PR TITLE
Fix/#29 o auth(kakao) login api

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/throttler": "^3.1.0",
     "@nestjs/typeorm": "^9.0.1",
     "@types/mjml": "^4.7.0",
+    "axios": "^1.2.2",
     "bcrypt": "^5.1.0",
     "cache-manager": "^5.1.3",
     "cache-manager-ioredis": "^2.1.0",

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -50,7 +50,7 @@ export const TypeormConfigOptions = {
         ProposalImageEntity,
         ProposalLikeEntity,
       ],
-      timezone: 'z',
+      timezone: '+09:00',
       charset: 'utf8mb4',
       logging: configService.get(`${process.env.NODE_ENV}.database.logging`),
       synchronize: configService.get(

--- a/src/database/entities/user.entity.ts
+++ b/src/database/entities/user.entity.ts
@@ -62,15 +62,14 @@ export class UserEntity extends DefaultEntity {
   email: string;
 
   @Column({
-    name: 'kakao_id',
+    name: 'oauth_id',
     type: 'varchar',
     nullable: true,
     unique: true,
-    comment: '카카오 유저 ID',
+    comment: 'oAuth ID(kakao, google, etc...)',
   })
   @IsString()
-  @IsNotEmpty()
-  kakaoId: string;
+  oauthId: string;
 
   @Column({
     name: 'password',

--- a/src/database/repositories/user.repository.ts
+++ b/src/database/repositories/user.repository.ts
@@ -4,17 +4,18 @@ import { UserEntity } from '../entities';
 
 @TypeormRepository(UserEntity)
 export class UserRepository extends Repository<UserEntity> {
-  async findAccountByKakaoId(kakaoId: string) {
+  async findAccountByKakaoId(oauthId: string) {
     const userData = await this.findOne({
-      where: { kakaoId: kakaoId },
+      where: { oauthId: oauthId, registerMethod: 'KAKAO' },
     });
+
     if (!userData) {
       return false;
     } else {
       return userData;
     }
   }
-  
+
   async findAccountByEmail(email) {
     const userData = await this.findOne({
       where: { email: email },
@@ -53,6 +54,26 @@ export class UserRepository extends Repository<UserEntity> {
   async getUserData(userId: number) {
     return await this.findOne({
       where: { userId: userId },
+    });
+  }
+
+  async createUserKakaoData(
+    email: string,
+    oauthId: string,
+    nickname: string,
+    marketingReception: boolean,
+    registerMethod: string,
+  ) {
+    await this.insert({
+      nickname,
+      email,
+      oauthId,
+      registerMethod,
+      contactInfoPublic: true,
+      trendingPlanner: false,
+      trendingFielder: false,
+      trendingFinder: false,
+      marketingReception,
     });
   }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { AdminRepository } from '../../database/repositories/admin.repository';
 import { SmtpConfig } from '../../config/smtp.config';
 import { JwtStrategy } from './jwt/jwt.strategy';
 import { RefreshStrategy } from './jwt/refresh.strategy';
+import { KakaoStrategy } from './jwt/kakao.strategy';
 import * as redisStore from 'cache-manager-ioredis';
 
 @Module({
@@ -39,6 +40,12 @@ import * as redisStore from 'cache-manager-ioredis';
     PassportModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, SmtpConfig, JwtStrategy, RefreshStrategy],
+  providers: [
+    AuthService,
+    SmtpConfig,
+    JwtStrategy,
+    RefreshStrategy,
+    KakaoStrategy,
+  ],
 })
 export class AuthModule {}

--- a/src/modules/auth/dto/req/oAuthSignup-req.dto.ts
+++ b/src/modules/auth/dto/req/oAuthSignup-req.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class OauthSignupReqDto {
+  @ApiProperty({
+    required: true,
+    type: String,
+    description: '카카오 로그인 실패(NOT FOUND)시 백엔드로 부터 받은 kakaoId',
+  })
+  @IsNotEmpty()
+  oauthId: string;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+    description: 'account Type',
+  })
+  @IsNotEmpty()
+  registerMethod: string;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+    description: '이메일',
+  })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @ApiProperty({
+    required: true,
+    type: Boolean,
+    description: '마케팅 수신 동의 여부',
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  marketingReception: boolean;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+    description: '닉네임',
+  })
+  @IsString()
+  @IsNotEmpty()
+  nickname: string;
+}

--- a/src/modules/auth/dto/res/kakao-userInfo-res.dto.ts
+++ b/src/modules/auth/dto/res/kakao-userInfo-res.dto.ts
@@ -6,7 +6,7 @@ export class KakaoUserInfosResDto {
     type: Number,
     description: 'kakao_id',
   })
-  target_id: number;
+  id: number;
 
   @ApiProperty({
     type: String,

--- a/src/modules/auth/jwt/kakao.strategy.ts
+++ b/src/modules/auth/jwt/kakao.strategy.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import QueryString from 'qs';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
 import { KakaoTokensResDto } from '../dto/res/kakao-tokens-res.dto';
 import { KakaoUserInfosResDto } from '../dto/res/kakao-userInfo-res.dto';
 
@@ -11,32 +12,39 @@ export class KakaoStrategy {
   redirectUri: string;
   code: string;
 
-  constructor() {
+  constructor(private readonly configService: ConfigService) {
     this.url = 'https://kauth.kakao.com';
-    this.clientID = `${process.env.NODE_ENV}.auth.kakao.client_id`;
-    this.redirectUri = `${process.env.NODE_ENV}.auth.kakao.redirectUri`;
+    this.clientID = configService.get(
+      `${process.env.NODE_ENV}.auth.kakao.client_id`,
+    );
+    this.redirectUri = configService.get(
+      `${process.env.NODE_ENV}.auth.kakao.redirect_uri`,
+    );
   }
 
   getToken = async (code: string): Promise<KakaoTokensResDto> => {
     let response: any;
 
-    await fetch(this.url + '/oauth/token', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded;charset=utf-8',
-      },
-      body: QueryString.stringify({
-        grant_type: 'authorization_code',
-        client_id: this.clientID,
-        redirectUri: this.redirectUri,
-        code: code,
-      }),
-    })
+    await axios
+      .post(
+        this.url + '/oauth/token',
+        {
+          grant_type: 'authorization_code',
+          client_id: this.clientID,
+          redirectUri: this.redirectUri,
+          code: code,
+        },
+        {
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+          },
+        },
+      )
       .then((res) => {
-        response = res.json();
+        response = res.data;
       })
       .catch((err) => {
-        response = err.json();
+        response = err;
       });
 
     return response;
@@ -45,15 +53,15 @@ export class KakaoStrategy {
   getUserInfo = async (accessToken: string): Promise<KakaoUserInfosResDto> => {
     let response: any;
 
-    await fetch('https://kapi.kakao.com/v2/user/me', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'content-type': 'application/x-www-form-urlencoded;charset=utf-8',
-      },
-    })
+    await axios
+      .get('https://kapi.kakao.com/v2/user/me', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+        },
+      })
       .then((res) => {
-        response = res.json();
+        response = res.data;
       })
       .catch((err) => {
         response = err;


### PR DESCRIPTION
> ## Summary
- 카카오 로그인 API 와 로그인 실패(folloca user가 아닌 경우)에 따른 회원가입 API 추가

> ## Description of your changes
REST API 통신은 Axios 사용
카카오 로그인 성공시 Callback URL로 방문시 자동 실행 
로그인 성공시 인가받은 code 값으로 accessToken API 통신
accessToken 취득 후 유저 정보 API 통신
유저정보 중 kakao_id를 토대로 DB 조회


> ## Issue number and link
#29

> ## Notice for the team
npm install  (axios 설치했습니다)