### PR TITLE
[feat] #47 - user withdrawal API

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -299,4 +299,32 @@ export class AuthController {
       nickname,
     );
   }
+
+  @Delete('/withdrawal')
+  @ApiOperation({
+    summary: '회원 탈퇴',
+    description: '유저 회원 탈퇴',
+  })
+  @ApiBody({
+    schema: {
+      properties: {
+        email: { type: 'string' },
+      },
+    },
+  })
+  async withdrawal(@Res() res, @Body() body) {
+    await this.authService.deleteRefreshToken(body.email);
+    await this.authService.withdrawal(body.email);
+
+    res
+      .setHeader('Authorization')
+      .cookie('refresh', {
+        path: '/',
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+      })
+      .status(HttpStatus.OK)
+      .send({ message: `Withdrawal success` });
+  }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -370,4 +370,8 @@ export class AuthService {
       });
     }
   }
+
+  async withdrawal(email: string) {
+    await this.userRepository.deleteAccountByEmail(email);
+  }
 }

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -109,4 +109,8 @@ export class UserRepository extends Repository<UserEntity> {
       },
     );
   }
+
+  async deleteAccountByEmail(email: string) {
+    return await this.softDelete({ email: email });
+  }
 }


### PR DESCRIPTION
> ## Summary
- 회원탈퇴 기능 추가

> ## Description of your changes
회원 탈퇴 기능을 추가하였습니다.
컬럼은 따로 추가하지 않았고, soft delete 과정으로 진행했습니다.

> ## Issue number and link
#47

> ## Notice for the team
로그인(email, oAuth) 로직 중 query 사용시 delete_at is not null 추가해야할 것 같습니다.
현재로썬 탈퇴이후에도 정상 로그인이 가능할 것 같습니다.