### PR TITLE
[feat] #56 - Add transaction process

### DIFF
--- a/src/repositories/functions.ts
+++ b/src/repositories/functions.ts
@@ -1,0 +1,19 @@
+import { Logger } from '@nestjs/common';
+
+export const executeQueryWithTransaction = async (connection, query) => {
+  const queryRunner = connection.createQueryRunner();
+  await queryRunner.connect();
+  await queryRunner.startTransaction();
+
+  try {
+    await query;
+    await queryRunner.commitTransaction();
+    Logger.log('Transaction commit success');
+  } catch (err) {
+    await queryRunner.rollbackTransaction();
+    Logger.error('Transaction rollback');
+  } finally {
+    await queryRunner.release();
+    Logger.log('Transaction released');
+  }
+};


### PR DESCRIPTION
> ## Summary
- 트랜잭션 추가

> ## Description of your changes
- TypeORM queryRunner를 통한 DB 트랜잭션 처리 방식 추가
- https://typeorm.io/transactions#using-queryrunner-to-create-and-control-state-of-single-database-connection
- 현재 estates API에서 공간 등록과 좋아요 추가 시에 적용
- repository 레벨에서 재사용 가능하도록 별도로 트랜잭션 함수로 생성 및 사용
- 테스트 디렉토리 추가

> ## Issue number and link
#56 

> ## Notice for the team
repository 디렉토리에 functions.ts로 트랜잭션 함수가 있습니다.
entityManager와 connection을 통해 각 repository 클래스에서 connection을 생성하고, connection과 query를 인자로 넘겨 트랜잭션을 통해 쿼리문을 실행합니다.