### PR TITLE
[fix] #59 - User logout logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs-modules/ioredis": "^1.0.1",
     "@nestjs/axios": "^1.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.2.0",

--- a/src/config/config-template.yaml
+++ b/src/config/config-template.yaml
@@ -27,6 +27,14 @@ local:
   redis:
     host:
     port:
+    index:
+      auth:
+      admin:
+      estate:
+      linking:
+      proposal:
+      search:
+      user:
     database:
     username:
     password:

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ async function bootstrap() {
     .addCookieAuth(
       'auth-cookie',
       {
-        type: 'http',
+        type: 'apiKey',
         in: 'cookie',
       },
       'refresh',

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,12 +63,12 @@ async function bootstrap() {
       'auth-cookie',
       {
         type: 'http',
-        in: 'Header',
+        in: 'cookie',
       },
       'refresh',
     )
     .addBearerAuth(
-      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT', in: 'Header' },
       'access-token',
     )
     .build();

--- a/src/middleware/multer-user-id.middleware.ts
+++ b/src/middleware/multer-user-id.middleware.ts
@@ -1,15 +1,40 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
 
 @Injectable()
 export class MulterUserIdMiddleware implements NestMiddleware {
-  constructor(private jwtService: JwtService) {}
+  private redis: Redis;
+  constructor(
+    private configService: ConfigService,
+    private jwtService: JwtService,
+  ) {
+    this.redis = new Redis({
+      host: configService.get(`${process.env.NODE_ENV}.redis.host`),
+      port: configService.get(`${process.env.NODE_ENV}.redis.port`),
+      db: configService.get(`${process.env.NODE_ENV}.redis.index.auth`),
+    });
+  }
 
   async use(req: Request, res: Response, next: NextFunction) {
-    const token = req.headers.authorization.replace('Bearer', '').trim();
-    const { userId } = await this.jwtService.verifyAsync(token);
-    req.query.userId = userId;
-    next();
+    const token = req.headers.authorization.replace('Bearer ', '').trim();
+
+    if (await this.redis.get(`black_${token}`)) {
+      res.status(403).send({
+        message: 'Blacklist Token',
+      });
+    }
+
+    try {
+      const { userId } = await this.jwtService.verifyAsync(token);
+      req.query.userId = userId;
+      next();
+    } catch (err) {
+      res.status(401).send({
+        message: 'Expired Token',
+      });
+    }
   }
 }

--- a/src/modules/auth.module.ts
+++ b/src/modules/auth.module.ts
@@ -37,10 +37,14 @@ import { RedisModule } from '@nestjs-modules/ioredis';
           `${process.env.NODE_ENV}.redis.port`,
         );
 
+        const index = await configService.get(
+          `${process.env.NODE_ENV}.redis.index.auth`,
+        );
+
         return {
           config: {
             url: `redis://${host}:${port}`,
-            db: 1,
+            db: index,
           },
         };
       },

--- a/src/modules/auth.module.ts
+++ b/src/modules/auth.module.ts
@@ -1,4 +1,4 @@
-import { CacheModule, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { AuthController } from '../controllers/auth.controller';
 import { AuthService } from '../services/auth.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -10,8 +10,8 @@ import { AdminRepository } from '../repositories/admin.repository';
 import { SmtpConfig } from '../config/smtp.config';
 import { JwtStrategy } from '../auth/jwt.strategy';
 import { KakaoStrategy } from '../auth/kakao.strategy';
-import * as redisStore from 'cache-manager-ioredis';
 import { GoogleStrategy } from '../auth/google.strategy';
+import { RedisModule } from '@nestjs-modules/ioredis';
 
 @Module({
   imports: [
@@ -27,15 +27,24 @@ import { GoogleStrategy } from '../auth/google.strategy';
         signOptions: { expiresIn: '1d' },
       }),
     }),
-    CacheModule.registerAsync({
+    RedisModule.forRootAsync({
       imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => {
+        const host = await configService.get(
+          `${process.env.NODE_ENV}.redis.host`,
+        );
+        const port = await configService.get(
+          `${process.env.NODE_ENV}.redis.port`,
+        );
+
+        return {
+          config: {
+            url: `redis://${host}:${port}`,
+            db: 1,
+          },
+        };
+      },
       inject: [ConfigService],
-      useFactory: async (configService: ConfigService) => ({
-        store: redisStore,
-        host: configService.get(`${process.env.NODE_ENV}.redis.host`),
-        port: configService.get(`${process.env.NODE_ENV}.redis.port`),
-        ttl: 1209600,
-      }),
     }),
     PassportModule,
   ],


### PR DESCRIPTION
> ## Summary
- 로그아웃 로직 수정 

> ## Description of your changes
- Redis Module 추가 방법
사용하고자 하는 Module에서 아래의 이미지와 같이 import 해주시고
<img width="476" alt="스크린샷 2023-04-14 11 03 17" src="https://user-images.githubusercontent.com/51731660/231923001-bae6278e-d3e6-4c88-8375-626f13294a45.png">
Service 단에 아래의 이미지와 같이 추가 `@InjectRedis() private readonly redis: Redis` 하시면 `this.redis` 사용가능합니다.
<img width="435" alt="스크린샷 2023-04-14 11 04 56" src="https://user-images.githubusercontent.com/51731660/231923212-a967bde4-66b4-4ee8-b8a7-77f4e3a08dc0.png">

- 로그아웃 로직
로그아웃을 진행할 경우 `refresh token`의 경우 redis에서 제거를, `access token`의 경우 `blacklist token`으로 등록하는 로직을 추가했습니다. 

- Middleware
middleware 단에서 현재 API를 콜할 때 사용된 access token이 blacklist token인지 체크하는 로직(해당 경우 `403 status code` return)과 만료된 토큰인지 검사하는 로직(해당 경우 `401 status code` return)을 추가하였습니다.

> ## Issue number and link
#59 

> ## Notice for the team
1. npm install
2. config template가 수정되었습니다. 확인 후 수정 부탁드려요
3. access token의 만료시간을 5분으로 설정해 두었습니다.
    `local`에서 개발 당시 불편하실 경우
    `auth.service.ts`의 `getAccessToken` 함수에서 2번째 파라미터 제거하시면 default인 하루로 설정됩니다.