### PR TITLE
Fix/#63 fix reissuance access token

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -336,12 +336,10 @@ export class AuthController {
   @ApiOperation({
     summary: '토큰 재발급 요청',
   })
-  @ApiCookieAuth('refresh')
+  @ApiCookieAuth()
   async refreshToken(@Req() req, @Res() res) {
-    if (req.headers.authorization) {
-      const refreshToken = req.headers.authorization
-        .replace('Bearer ', '')
-        .trim();
+    if (req.cookies['refresh']) {
+      const refreshToken = req.cookies['refresh'];
 
       const accessToken = await this.authService.validateRefreshToken(
         refreshToken,

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,14 +59,7 @@ async function bootstrap() {
     .setTitle('FOLLOCA')
     .setDescription('Swagger document for FOLLOCA API server')
     .setVersion(pkg.version)
-    .addCookieAuth(
-      'auth-cookie',
-      {
-        type: 'apiKey',
-        in: 'cookie',
-      },
-      'refresh',
-    )
+    .addCookieAuth('refresh')
     .addBearerAuth(
       { type: 'http', scheme: 'bearer', bearerFormat: 'JWT', in: 'Header' },
       'access-token',

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -151,7 +151,7 @@ export class AuthService {
     return refreshToken;
   }
 
-  async validateRefreshToken(refreshToken) {
+  async validateRefreshToken(refreshToken: string) {
     const { userId, email } = await this.jwtService.verifyAsync(refreshToken);
     const tokenData = await this.redis.get(`refresh_${email}`);
     const tokenVerification = await bcrypt.compare(refreshToken, tokenData);


### PR DESCRIPTION
> ## Summary
Access Token 재발급 API를 일부 수정했습니다.

> ## Description of your changes
NestJS + Swagger의 사용에 아직 익숙지 못하여 Cookie 값을 정상적으로 담지 못하여
RefreshToken을 header에 담아 API 통신을 진행했었던 부분을 cookie로 변경하였습니다.

해당 부분 수정 후 로컬에서 테스트 진행 중에도 Swagger로는 원활히 진행하지 못하였으며,
Postman으로 API 통신시 원활히 진행됨을 확인하였습니다.

> ## Issue number and link
#63 

> ## Notice for the team
Noting