### PR TITLE
[feat] #67 - Add estate search API

### DIFF
--- a/src/controllers/estates.controller.ts
+++ b/src/controllers/estates.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Param,
   Post,
   Query,
   UploadedFiles,
@@ -13,6 +14,7 @@ import {
   ApiBody,
   ApiConsumes,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -76,6 +78,21 @@ export class EstatesController {
       PriorFilterEnumToEng[priorFilter],
       PosteriorFilterEnumToEng[posteriorFilter],
     );
+  }
+
+  @Get('/:estateId')
+  @ApiOperation({
+    summary: '공간 상세 조회',
+    description: '공간 상세 조회',
+  })
+  @ApiParam({
+    name: 'estateId',
+    type: String,
+    required: true,
+    description: '공간 id',
+  })
+  async getEstate(@Param('estateId') estateId) {
+    return await this.estatesService.getEstateById(+estateId);
   }
 
   @Post()

--- a/src/controllers/estates.controller.ts
+++ b/src/controllers/estates.controller.ts
@@ -81,8 +81,9 @@ export class EstatesController {
   }
 
   @Get('/:estateId')
+  @ApiBearerAuth('access-token')
   @ApiOperation({
-    summary: '공간 상세 조회',
+    summary: '공간 상세 조회(기획 모듈 개발 후 완료 예정)',
     description: '공간 상세 조회',
   })
   @ApiParam({
@@ -91,8 +92,8 @@ export class EstatesController {
     required: true,
     description: '공간 id',
   })
-  async getEstate(@Param('estateId') estateId) {
-    return await this.estatesService.getEstateById(+estateId);
+  async getEstate(@GetUserId() userId, @Param('estateId') estateId) {
+    return await this.estatesService.getEstateById(userId, +estateId);
   }
 
   @Post()

--- a/src/custom/pipe/get-user-id.pipe.ts
+++ b/src/custom/pipe/get-user-id.pipe.ts
@@ -6,8 +6,12 @@ export class GetUserIdPipe implements PipeTransform {
   constructor(private jwtService: JwtService) {}
 
   async transform(value: any) {
-    const token = value.replace('Bearer', '').trim();
-    const { userId } = await this.jwtService.verifyAsync(token);
-    return userId;
+    if (!value.startsWith('Bearer')) {
+      return 0;
+    } else {
+      const token = value.replace('Bearer', '').trim();
+      const { userId } = await this.jwtService.verifyAsync(token);
+      return userId;
+    }
   }
 }

--- a/src/database/entities/estate-image.entity.ts
+++ b/src/database/entities/estate-image.entity.ts
@@ -27,12 +27,12 @@ export class EstateImageEntity extends DateColumnEntity {
   estateId: number;
 
   @Column({
-    name: 'image_path',
+    name: 'image',
     type: 'varchar',
     nullable: false,
-    comment: '공간 이미지 저장 경로',
+    comment: '공간 이미지 파일명',
   })
   @IsString()
   @IsNotEmpty()
-  imagePath: string;
+  imageName: string;
 }

--- a/src/database/entities/estate-like.entity.ts
+++ b/src/database/entities/estate-like.entity.ts
@@ -16,11 +16,11 @@ export class EstateLikeEntity extends DateColumnEntity {
     onDelete: 'CASCADE',
   })
   @JoinColumn([{ name: 'user_id', referencedColumnName: 'userId' }])
-  userId: UserEntity;
+  userId: number;
 
   @ManyToOne(() => EstateEntity, (estate: EstateEntity) => estate.estateLikes, {
     onDelete: 'CASCADE',
   })
   @JoinColumn([{ name: 'estate_id', referencedColumnName: 'estateId' }])
-  estateId: EstateEntity;
+  estateId: number;
 }

--- a/src/database/entities/estate-tag.entity.ts
+++ b/src/database/entities/estate-tag.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { EstateEntity } from './estate.entity';
 import { HashTagEntity } from './hash-tag.entity';
 
@@ -19,6 +25,12 @@ export class EstateTagEntity {
     },
   )
   @JoinColumn([{ name: 'hash_tag_id', referencedColumnName: 'hashTagId' }])
+  @Column({
+    name: 'hash_tag_id',
+    type: 'number',
+    nullable: false,
+    comment: '해시태그 id',
+  })
   hashTagId: number;
 
   @ManyToOne(() => EstateEntity, (estate: EstateEntity) => estate.estateTags, {

--- a/src/dto/res/get-estate-res.dto.ts
+++ b/src/dto/res/get-estate-res.dto.ts
@@ -1,0 +1,141 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString } from 'class-validator';
+import { Expose, Transform } from 'class-transformer';
+import * as path from 'path';
+import dayjs from 'dayjs';
+
+export class GetEstateResDto {
+  @ApiProperty({
+    name: 'estateId',
+    type: Number,
+    description: '공간 id',
+  })
+  @Expose()
+  @IsNumber()
+  estateId: number;
+
+  @ApiProperty({
+    name: 'ownerId',
+    type: Number,
+    description: '소유자 id',
+  })
+  @Expose()
+  @IsNumber()
+  ownerId: number;
+
+  @ApiProperty({
+    name: 'thumbnailPath',
+    type: String,
+    description: '대표 이미지 경로',
+  })
+  @Transform(
+    ({ value }) =>
+      `${path.join(__dirname, '..', '..', '..', 'storage', 'estate')}/${value}`,
+  )
+  @Expose()
+  @IsString()
+  thumbnailPath: string;
+
+  @ApiProperty({
+    name: 'estateName',
+    type: String,
+    description: '공간 이름',
+  })
+  @Expose()
+  @IsString()
+  estateName: string;
+
+  @ApiProperty({
+    name: 'estateKeyword',
+    type: String,
+    description: '공간 키워드',
+  })
+  @Expose()
+  @IsString()
+  estateKeyword: string;
+
+  @ApiProperty({
+    name: 'estateTheme',
+    type: String,
+    description: '공간 주제',
+  })
+  @Expose()
+  @IsString()
+  estateTheme: string;
+
+  @ApiProperty({
+    name: 'estateUse',
+    type: String,
+    description: '공간 유형',
+  })
+  @Transform(({ value }) => (value === 0 ? '팝업' : '전시'))
+  @Expose()
+  @IsString()
+  estateUse: string;
+
+  @ApiProperty({
+    name: 'extent',
+    type: Number,
+    description: '면적',
+  })
+  @Expose()
+  @IsNumber()
+  extent: number;
+
+  @ApiProperty({
+    name: 'capacity',
+    type: Number,
+    description: '수용 인원',
+  })
+  @Expose()
+  @IsNumber()
+  capacity: number;
+
+  @ApiProperty({
+    name: 'price',
+    type: Number,
+    description: '가격',
+  })
+  @Expose()
+  @IsNumber()
+  price: number;
+
+  @ApiProperty({
+    name: 'ownerMessage',
+    type: String,
+    description: '공간 소유자의 한마디',
+  })
+  @Expose()
+  @IsString()
+  ownerMessage: string;
+
+  @ApiProperty({
+    name: 'proposalDeadline',
+    type: String,
+    description: '기획 마감 일자',
+  })
+  @Transform(({ value }) => dayjs(value).format('YYYY-MM-DD HH:mm'))
+  @Expose()
+  @IsString()
+  proposalDeadline: string;
+
+  @ApiProperty({
+    name: 'createdAt',
+    type: String,
+    description: '등록 일자',
+  })
+  @Transform(({ value }) => dayjs(value).format('YYYY-MM-DD HH:mm'))
+  @Expose()
+  @IsString()
+  createdAt: string;
+
+  @ApiProperty({
+    name: 'updatedAt',
+    type: String,
+    description: '수정 일자',
+  })
+  @Transform(({ value }) => dayjs(value).format('YYYY-MM-DD HH:mm'))
+  @Expose()
+  @IsString()
+  updatedAt: string;
+}

--- a/src/middleware/multer-user-id.middleware.ts
+++ b/src/middleware/multer-user-id.middleware.ts
@@ -19,21 +19,21 @@ export class MulterUserIdMiddleware implements NestMiddleware {
   }
 
   async use(req: Request, res: Response, next: NextFunction) {
-    const token = req.headers.authorization.replace('Bearer ', '').trim();
-
-    if (await this.redis.get(`black_${token}`)) {
-      res.status(403).send({
-        message: 'Blacklist Token',
-      });
-    }
-
     try {
+      const token = req.headers.authorization.replace('Bearer ', '').trim();
+
+      if (await this.redis.get(`black_${token}`)) {
+        res.status(403).send({
+          message: 'Blacklist Token',
+        });
+      }
+
       const { userId } = await this.jwtService.verifyAsync(token);
       req.query.userId = userId;
       next();
     } catch (err) {
       res.status(401).send({
-        message: 'Expired Token',
+        message: 'Expired or invalid Token',
       });
     }
   }

--- a/src/repositories/estate.repository.ts
+++ b/src/repositories/estate.repository.ts
@@ -67,6 +67,10 @@ export class EstateRepository extends Repository<EstateEntity> {
       .getRawMany();
   }
 
+  async getEstateData(estateId: number) {
+    return await this.findOneBy({ estateId });
+  }
+
   async createEstateData(
     userId: number,
     createEstateDto: CreateEstateDto,
@@ -164,6 +168,11 @@ export class MapNumberingRepository extends Repository<MapNumberingEntity> {
 @TypeormRepository(EstateLikeEntity)
 export class EstateLikeRepository extends Repository<EstateLikeEntity> {
   private managerConnection = this.manager.connection;
+
+  async checkLike(userId: number, estateId: number): Promise<boolean> {
+    const result = await this.findOneBy({ userId, estateId });
+    return !!result;
+  }
 
   async addLike(userId: number, estateId: number) {
     const query = this.createQueryBuilder()

--- a/src/repositories/hash-tag.repository.ts
+++ b/src/repositories/hash-tag.repository.ts
@@ -6,6 +6,15 @@ import { EstateTagEntity, HashTagEntity } from '../database/entities';
 export class HashTagRepository extends Repository<HashTagEntity> {
   private managerConnection = this.manager.connection;
 
+  async getHashTagData(hashTagIds: number[]) {
+    return await Promise.all(
+      hashTagIds.map(async (id) => {
+        const { word } = await this.findOneBy({ hashTagId: id });
+        return word;
+      }),
+    );
+  }
+
   async createHashTag(words: string[]) {
     return await Promise.all(
       words.map(async (word) => {
@@ -24,6 +33,11 @@ export class HashTagRepository extends Repository<HashTagEntity> {
 @TypeormRepository(EstateTagEntity)
 export class EstateTagRepository extends Repository<EstateTagEntity> {
   private managerConnection = this.manager.connection;
+
+  async getTagIds(estateId: number) {
+    const result = await this.findBy({ estateId });
+    return result.map((el) => el.hashTagId);
+  }
 
   async createEstateTag(estateId: number, hashTagIds: number[]) {
     await Promise.all(

--- a/src/repositories/image.repository.ts
+++ b/src/repositories/image.repository.ts
@@ -1,14 +1,27 @@
 import { TypeormRepository } from '../custom/decorator/typeorm-repository.decorator';
 import { Repository } from 'typeorm';
 import { EstateImageEntity } from '../database/entities';
+import * as path from 'path';
 
 @TypeormRepository(EstateImageEntity)
 export class EstateImageRepository extends Repository<EstateImageEntity> {
   private managerConnection = this.manager.connection;
 
+  async getImageData(estateId: number) {
+    const imageData = await this.findBy({ estateId });
+    return await Promise.all(
+      imageData.map(
+        (el) =>
+          `${path.join(__dirname, '..', '..', '..', 'storage', 'estate')}/${
+            el.imageName
+          }`,
+      ),
+    );
+  }
+
   async createImageData(estateId: number, filenames: string[]) {
     const data = filenames.map((filename) => {
-      return { estateId, imagePath: filename };
+      return { estateId, imageName: filename };
     });
     await this.save(data);
   }


### PR DESCRIPTION
> ## Summary
공간 상세 조회 API

> ## Description of your changes
- 특정 공간 id에  해당하는 공간 조회 API 기능 추가
- 커스텀 파이프와 multer에서 토큰 검증하는 미들웨어의 authorization header 값에 따른 분기 처리
  - 공간 상세 조회는 로그인을 하지 않아도 API 호출이 가능한 기능이지만 좋아요 여부 확인을 위해 토큰이 필요했고, 토큰 없이 요청 보낼 경우도 API가 정상 동작하도록 수정
- 공간 entity 객체 관리를 위한 DTO 추가
- 각 repository에 필요한 조회 함수 추가
- entity 컬럼 타입 수정
- 현재 API 응답 예시
```js
{
  "data": {
    "estateId": 140,
    "ownerId": 2,
    "thumbnailPath": "/Users/mingi/Self-Study/FOLLOCA/server-backend/storage/estate/undefined",
    "estateName": "dldl",
    "estateKeyword": "dldl",
    "estateTheme": "dldl",
    "estateUse": "팝업",
    "extent": 123,
    "capacity": 40,
    "price": 6000,
    "ownerMessage": null,
    "proposalDeadline": "2023-08-23 18:00",
    "createdAt": "2023-04-20 05:34",
    "updatedAt": "2023-04-20 05:34",
    "totalLikes": 0,
    "likeOrNot": false,
    "estateImages": [
      "/Users/mingi/Self-Study/FOLLOCA/storage/estate/0cf08c99-6d26-40d6-a543-52ee0b78706c.png",
      "/Users/mingi/Self-Study/FOLLOCA/storage/estate/9477379d-28b3-44d4-8b21-2c0874288260.png",
      "/Users/mingi/Self-Study/FOLLOCA/storage/estate/561b257b-3625-4c9e-81c2-d4c061b7f892.png"
    ],
    "estateHashTags": [
      "해시",
      "태그"
    ]
  },
  "message": "Detail information of estate 140"
}
```


> ## Issue number and link
#67

> ## Notice for the team
기획 모듈 개발 후에 마무리 예정: 공간 상세 조회 시, 해당 공간의 기획 리스트도 조회되어야 하기 때문.