### PR TITLE
[feat] #72 - Add proposal edit and delete API

### DIFF
--- a/src/dto/req/update-proposal.dto.ts
+++ b/src/dto/req/update-proposal.dto.ts
@@ -13,12 +13,12 @@ export class UpdateProposalDto {
   @ApiProperty({
     required: true,
     type: Number,
-    description: '공간 id',
+    description: '기획 id',
   })
   @Type(() => Number)
   @IsNumber()
   @IsNotEmpty()
-  estateId: number;
+  proposalId: number;
 
   @ApiProperty({
     required: true,
@@ -71,7 +71,7 @@ export class UpdateProposalDto {
     description:
       '구체화 방안(평면도가 존재하지 않을 경우, "0"을 key로 string value 1200자까지 하나만 작성 가능)',
   })
-  @Transform(({ value }) => JSON.parse(value))
+  @Transform(({ value }) => (value ? JSON.parse(value) : null))
   @IsOptional()
   proposalDetails: ProposalDetailsDto;
 

--- a/src/dto/req/update-proposal.dto.ts
+++ b/src/dto/req/update-proposal.dto.ts
@@ -1,0 +1,104 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBooleanString,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { ProposalDetailsDto } from './create-proposal.dto';
+
+export class UpdateProposalDto {
+  @ApiProperty({
+    required: true,
+    type: Number,
+    description: '공간 id',
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @IsNotEmpty()
+  estateId: number;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+    maxLength: 20,
+    description: '한 줄 소개(20자 이내)',
+  })
+  @IsString()
+  @IsOptional()
+  proposalIntroduction: string;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+    maxLength: 200,
+    description: '설명(200자 이내)',
+  })
+  @IsString()
+  @IsOptional()
+  proposalDescription: string;
+
+  @ApiProperty({
+    required: false,
+    type: String,
+    maxLength: 7,
+    description: '해시태그1(최대 7글자)',
+  })
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsString()
+  @IsOptional()
+  hashTag1: string;
+
+  @ApiProperty({
+    required: false,
+    type: String,
+    maxLength: 7,
+    description: '해시태그2(최대 7글자)',
+  })
+  @Transform(({ value }) => (value === '' ? undefined : value))
+  @IsString()
+  @IsOptional()
+  hashTag2: string;
+
+  @ApiProperty({
+    required: false,
+    type: Object,
+    additionalProperties: {
+      type: 'string',
+    },
+    description:
+      '구체화 방안(평면도가 존재하지 않을 경우, "0"을 key로 string value 1200자까지 하나만 작성 가능)',
+  })
+  @Transform(({ value }) => JSON.parse(value))
+  @IsOptional()
+  proposalDetails: ProposalDetailsDto;
+
+  @ApiProperty({
+    required: true,
+    type: Boolean,
+    description: '의견 받기 여부',
+  })
+  @IsBooleanString()
+  @IsOptional()
+  opinionOpen: boolean;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+    format: 'binary',
+    description: '대표 이미지',
+  })
+  @IsOptional()
+  thumbnail: Express.Multer.File;
+
+  @ApiProperty({
+    required: false,
+    type: Array,
+    format: 'binary',
+    description: '기획 이미지(최대 6장)',
+  })
+  @IsOptional()
+  images: Express.Multer.File;
+}

--- a/src/dto/req/update-proposal.dto.ts
+++ b/src/dto/req/update-proposal.dto.ts
@@ -21,7 +21,7 @@ export class UpdateProposalDto {
   proposalId: number;
 
   @ApiProperty({
-    required: true,
+    required: false,
     type: String,
     maxLength: 20,
     description: '한 줄 소개(20자 이내)',
@@ -31,7 +31,7 @@ export class UpdateProposalDto {
   proposalIntroduction: string;
 
   @ApiProperty({
-    required: true,
+    required: false,
     type: String,
     maxLength: 200,
     description: '설명(200자 이내)',
@@ -76,7 +76,7 @@ export class UpdateProposalDto {
   proposalDetails: ProposalDetailsDto;
 
   @ApiProperty({
-    required: true,
+    required: false,
     type: Boolean,
     description: '의견 받기 여부',
   })
@@ -85,7 +85,7 @@ export class UpdateProposalDto {
   opinionOpen: boolean;
 
   @ApiProperty({
-    required: true,
+    required: false,
     type: String,
     format: 'binary',
     description: '대표 이미지',

--- a/src/dto/req/update-proposal.dto.ts
+++ b/src/dto/req/update-proposal.dto.ts
@@ -85,7 +85,7 @@ export class UpdateProposalDto {
   opinionOpen: boolean;
 
   @ApiProperty({
-    required: false,
+    required: true,
     type: String,
     format: 'binary',
     description: '대표 이미지',

--- a/src/dto/req/update-proposal.dto.ts
+++ b/src/dto/req/update-proposal.dto.ts
@@ -26,6 +26,7 @@ export class UpdateProposalDto {
     maxLength: 20,
     description: '한 줄 소개(20자 이내)',
   })
+  @Transform(({ value }) => (value === '' ? undefined : value))
   @IsString()
   @IsOptional()
   proposalIntroduction: string;
@@ -36,6 +37,7 @@ export class UpdateProposalDto {
     maxLength: 200,
     description: '설명(200자 이내)',
   })
+  @Transform(({ value }) => (value === '' ? undefined : value))
   @IsString()
   @IsOptional()
   proposalDescription: string;
@@ -80,6 +82,7 @@ export class UpdateProposalDto {
     type: Boolean,
     description: '의견 받기 여부',
   })
+  @Transform(({ value }) => (value === '' ? undefined : value))
   @IsBooleanString()
   @IsOptional()
   opinionOpen: boolean;

--- a/src/repositories/hash-tag.repository.ts
+++ b/src/repositories/hash-tag.repository.ts
@@ -54,11 +54,15 @@ export class EstateTagRepository extends Repository<EstateTagEntity> {
 
 @TypeormRepository(ProposalTagEntity)
 export class ProposalTagRepository extends Repository<ProposalTagEntity> {
-  async createEstateTag(proposalId: number, hashTagIds: number[]) {
+  async createProposalTag(proposalId: number, hashTagIds: number[]) {
     await Promise.all(
       hashTagIds.map(async (hashTagId) => {
         await this.save({ hashTagId, proposalId });
       }),
     );
+  }
+
+  async deleteProposalTag(proposalId: number) {
+    await this.delete({ proposalId });
   }
 }

--- a/src/repositories/image.repository.ts
+++ b/src/repositories/image.repository.ts
@@ -33,4 +33,8 @@ export class ProposalImageRepository extends Repository<ProposalImageEntity> {
     });
     await this.save(data);
   }
+
+  async deleteImageData(proposalId: number) {
+    await this.softDelete({ proposalId });
+  }
 }

--- a/src/repositories/image.repository.ts
+++ b/src/repositories/image.repository.ts
@@ -35,6 +35,6 @@ export class ProposalImageRepository extends Repository<ProposalImageEntity> {
   }
 
   async deleteImageData(proposalId: number) {
-    await this.softDelete({ proposalId });
+    await this.delete({ proposalId });
   }
 }

--- a/src/repositories/proposal.repository.ts
+++ b/src/repositories/proposal.repository.ts
@@ -28,6 +28,19 @@ export class ProposalRepository extends Repository<ProposalEntity> {
     };
     return await this.save(data);
   }
+
+  async getPlannerId(proposalId: number) {
+    const { plannerId } = await this.findOneBy({ proposalId });
+    return plannerId;
+  }
+
+  async updateProposalData(
+    proposalId: number,
+    thumbnail: string,
+    proposalIntroduction: string,
+    proposalDescription: string,
+    opinionOpen: boolean,
+  ) {}
 }
 
 @TypeormRepository(ProposalDetailEntity)

--- a/src/repositories/proposal.repository.ts
+++ b/src/repositories/proposal.repository.ts
@@ -41,10 +41,15 @@ export class ProposalRepository extends Repository<ProposalEntity> {
   async updateProposalData(
     proposalId: number,
     thumbnail: string,
-    proposalIntroduction: string,
-    proposalDescription: string,
-    opinionOpen: boolean,
-  ) {}
+    proposalIntroduction?: string,
+    proposalDescription?: string,
+    opinionOpen?: boolean,
+  ) {
+    await this.update(
+      { proposalId },
+      { thumbnail, proposalIntroduction, proposalDescription, opinionOpen },
+    );
+  }
 }
 
 @TypeormRepository(ProposalDetailEntity)
@@ -62,6 +67,21 @@ export class ProposalDetailRepository extends Repository<ProposalDetailEntity> {
       });
     }
     await this.save(data);
+  }
+
+  async updateDetailData(
+    proposalId: number,
+    proposalDetails: ProposalDetailsDto,
+  ) {
+    const data = [];
+    for (const detail of Object.entries(proposalDetails)) {
+      data.push({
+        proposalId,
+        mapNumbering: +detail[0],
+        detailDescription: detail[1],
+      });
+    }
+    await this.upsert(data, ['proposalId', 'mapNumbering']);
   }
 }
 

--- a/src/repositories/proposal.repository.ts
+++ b/src/repositories/proposal.repository.ts
@@ -34,6 +34,10 @@ export class ProposalRepository extends Repository<ProposalEntity> {
     return plannerId;
   }
 
+  async deleteProposal(proposalId: number) {
+    await this.delete({ proposalId });
+  }
+
   async updateProposalData(
     proposalId: number,
     thumbnail: string,

--- a/src/repositories/proposal.repository.ts
+++ b/src/repositories/proposal.repository.ts
@@ -35,7 +35,7 @@ export class ProposalRepository extends Repository<ProposalEntity> {
   }
 
   async deleteProposal(proposalId: number) {
-    await this.delete({ proposalId });
+    await this.softDelete({ proposalId });
   }
 
   async updateProposalData(


### PR DESCRIPTION
> ## Summary
기획 수정과 삭제 API 추가

> ## Description of your changes
- 기획 수정 및 삭제 기능 추가
- 기획 수정 시, 기존 이미지는 현재 그대로 주고 받는 방식으로 구현: 추후 최적화 예정
- 기획 id와 이미지는 필수로 요청에 포함시키고, 나머지는 변동 사항이 있을 경우 포함
- 수정과 삭제 기능 모두 user id 확인 절차 선행

> ## Issue number and link
#72 

> ## Notice for the team