### PR TITLE
[fix] #84 - Update user profile dashboard

### DIFF
--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -138,7 +138,11 @@ export class UsersController {
     description:
       '조회하고자 하는 유저의 Email(테스트에따라 닉네임으로 변경될 수도..)',
   })
-  async getProfileDashboard(@Query() query, @Res() res) {
+  async getProfileDashboard(
+    @GetUserId() currentUserId,
+    @Query() query,
+    @Res() res,
+  ) {
     const email = query.email;
 
     if (email) {
@@ -150,7 +154,7 @@ export class UsersController {
       const estates = await this.usersService.getEstateListByUserId(userId);
 
       if (userData) {
-        res.status(200).send({
+        const returnData = {
           profile: userData,
           dashboard: {
             post_cnt:
@@ -168,7 +172,13 @@ export class UsersController {
             linkings: linkings,
             estates: estates,
           },
-        });
+        };
+
+        if (currentUserId !== userId) {
+          delete returnData.dashboard;
+        }
+
+        res.status(200).send(returnData);
       } else {
         res.status(404).send({
           message: `Not Found User`,
@@ -283,8 +293,6 @@ export class UsersController {
         const recentPostList = await this.usersService.getLatestSeenPosts(
           recentIdList.posts,
         );
-
-        console.log(recentPostList.linkings);
 
         res.status(200).send({
           total_cnt: recentIdList.total_cnt,

--- a/src/custom/pipe/get-user-id.pipe.ts
+++ b/src/custom/pipe/get-user-id.pipe.ts
@@ -6,7 +6,7 @@ export class GetUserIdPipe implements PipeTransform {
   constructor(private jwtService: JwtService) {}
 
   async transform(value: any) {
-    if (!value.startsWith('Bearer')) {
+    if (!value || !value.startsWith('Bearer')) {
       return 0;
     } else {
       const token = value.replace('Bearer', '').trim();


### PR DESCRIPTION
> ## Summary
- 타인의 프로필 방문 시 response data 변경

> ## Description of your changes
- 이전 PR의 경우 비로그인, 타인 프로필, 본인 프로필의 경우를 신경쓰지 않고 모든 데이터를 전달하였으나 타인의 프로필 방문 시(로그인/비로그인) Dashboard (작성 게시글 수, 좋아요 수, 보낸 의견 수, 최근 본 수)의 데이터를 전달하지 않도록 수정하였습니다. 

> ## Issue number and link
#84 

> ## Notice for the team